### PR TITLE
Add slot=markers to first google-map example

### DIFF
--- a/google-map.html
+++ b/google-map.html
@@ -21,9 +21,9 @@ The `google-map` element renders a Google Map.
 <b>Example</b> - add markers to the map and ensure they're in view:
 
     <google-map latitude="37.77493" longitude="-122.41942" fit-to-markers>
-      <google-map-marker latitude="37.779" longitude="-122.3892"
+      <google-map-marker slot="markers" latitude="37.779" longitude="-122.3892"
           draggable="true" title="Go Giants!"></google-map-marker>
-      <google-map-marker latitude="37.777" longitude="-122.38911"></google-map-marker>
+      <google-map-marker slot="markers" latitude="37.777" longitude="-122.38911"></google-map-marker>
     </google-map>
 
 <b>Example</b>:


### PR DESCRIPTION
The `slot="markers"` attribute is essential in order to `<google-map>` element to be able to properly detect when each `<google-map-marker>` element inside it is inserted or updated.

For instance, properly triggering fit-to-markers and others actions.

This solution may solve this [#394 issue](https://github.com/GoogleWebComponents/google-map/issues/394) and even other issues.

How to solve: just add `slot="markers"` attribute to each of your added `<google-map-marker>` element.

The full explanation is [here](https://stackoverflow.com/a/50548226/1578202).

I'll repeat it here:

Adding `slot="marker"` attribute to each `<google-map-marker>` element should solve the issue.

Unfortunately the current example in the google-map component page does not insert this important attribute in each google-map-marker element.

Here is the current, without slot="markers" attribute, code example:

```html
<google-map latitude="37.77493" longitude="-122.41942" fit-to-markers>
    <google-map-marker latitude="37.779" longitude="-122.3892" draggable="true" title="Go Giants!">
    </google-map-marker>
    <google-map-marker latitude="37.777" longitude="-122.38911">
    </google-map-marker>
</google-map>
```

And below is the suggested corrected example that should be shown in the code (if my suggestion is correct):

```html
<google-map latitude="37.77493" longitude="-122.41942" fit-to-markers>
    <google-map-marker slot="markers" latitude="37.779" longitude="-122.3892" draggable="true" title="Go Giants!">
    </google-map-marker>
    <google-map-marker slot="markers" latitude="37.777" longitude="-122.38911">
    </google-map-marker>
</google-map>
```

What is happening?

`<google-map>` does not know when markers are inserted or updated because without the attribute `slot="markers"` each `<google-map-marker>` element is inserted outside the slot where they should be inserted in.

Several consequences can happen from this issue: the map can be viewed, but not respond to important events, like fit-to-markers.

In these turbulent moves from original without-slots version to the current slotted version (and soon moving to polymer 3.0 version) of the excellent google-map webcomponent, there is a high chance that the busy developers simply forgot to add this important slot="markers" attribute in the example that shows how to add each new google-map-marker webcomponent inside google-map.

Please correct me if I made wrong conclusions.

You can detect this flaw inspecting your `<google-map>` element. 

Open `<google-map>` in the inspector. Inside it, open `<iron-selector>`. Finally, inside it open the element `<slot id="markers" name="markers"><slot>`. If you do not use the suggested `slot="markers"` correction, this slot will be empty. If you use this suggested correction, this slot will contain references to each `<google-map-marker>`. And so the `<google-map>` element will be able to handle several events that rely on detecting when each marker is inserted or updated.

Sorry for the long answer. Again: please correct me if I made wrong conclusions.